### PR TITLE
🐛 (EDS-Pseudo-Toulouse): make split deterministic

### DIFF
--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -54,9 +54,9 @@ def split_dataset(
     full_xml_path = os.path.join(data_folder, 'full/xml')
 
     txt_files = [f for f in os.listdir(full_txt_path) if f.endswith('.txt')]
-    ##We need to sort the list in case listdir returns a different order depending on
-    ##how the files have been copy pasted in the full folder
-    txt_files.sort()
+    # We need to sort the list in case listdir returns a different order depending on
+    # how the files have been copy pasted in the full folder
+    txt_files = sorted(txt_files)
     random.shuffle(txt_files)
 
     dev_size = int(len(txt_files) * dev_percentage)

--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -54,9 +54,10 @@ def split_dataset(
     full_xml_path = os.path.join(data_folder, 'full/xml')
 
     txt_files = [f for f in os.listdir(full_txt_path) if f.endswith('.txt')]
+    ##We need to sort the list in case listdir returns a different order depending on
+    ##how the files have been copy pasted in the full folder
+    txt_files.sort()
     random.shuffle(txt_files)
-
-
 
     dev_size = int(len(txt_files) * dev_percentage)
     test_size = int(len(txt_files) * test_percentage)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Describe the changes. -->
We realized that when evaluating our pseudo model that the split-dataset spacy method wasn't deterministic even if it was in theory. The error either come from the fact that, on Toulouse Machine, the manual copy paste of the txt files in the full folder is not deterministic or that the `listdir` method from ` os ` isn't. 
Anyway, sorting the list obtained when reading the full folder manage to solve this issue.
I tested it on Toulouse machine and it solves the issue!

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation.
